### PR TITLE
BUG Fix PostgreSQL error when creating a table for namespaced data object

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -234,6 +234,7 @@ class PostgreSQLDatabase extends SS_Database {
 			$starttime = microtime(true);
 		}
 
+		$sql = str_replace("\\", "_", $sql); 
 		$handle = pg_query($this->dbConn, $sql);
 
 		if(isset($_REQUEST['showqueries'])) {


### PR DESCRIPTION
This issue is caused by the presence of backslash characters (PHP namespace delimiter) in entity names.
