### PR TITLE
Index fixes

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -1117,23 +1117,11 @@ class PostgreSQLDatabase extends SS_Database {
 			"SELECT tgargs FROM pg_catalog.pg_trigger WHERE tgname='%s'", $this->addslashes($triggerName)
 		))->first();
 
-		// Trigger columns will be extracted in an ugly hex format with null-
-		// terminated strings, needs some coaxing into a readable format
-		$tgargsHex = $trigger['tgargs'];
-		$tgargs = array();
-		$tgarg = '';
-		for ($i = 0; $i < strlen($tgargsHex); $i+=2) {
-			$hexChar = substr($tgargsHex, $i, 2);
-			if($hexChar == '00') {
-				$tgargs[] = $tgarg;
-				$tgarg = '';
-			} else {
-				$tgarg .= chr(hexdec($hexChar));
-			}
-		}
+		$argList = explode('\000', $trigger['tgargs']);
+		array_pop($argList);
 
 		// Drop first two arguments (trigger name and config name) and implode into nice list
-		return array_slice($tgargs, 2);
+		return array_slice($argList, 2);
 	}
 
 	/**


### PR DESCRIPTION
These commits are needed to fix the tests that I broke last night.  I opted for overriding PostgreSQLDatabase::requireIndex() rather than changing the API here.  Tidying up the APIs could be considered for 3.1, but not 3.0.

It's a bit of copy pasta but the lesser of two evils, IMO.

Note that this change will use different names for the indexes in a PostgreSQL database.  They're now based on MD5 checksums in order to prevent name collision in the case where the end of an index name is truncated.  None of the original indexes will be deleted, which is in keeping with dev/build's usual "only add, don't delete" way of operating.
