### PR TITLE
BUG Unescaped query fix

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -1264,7 +1264,7 @@ class PostgreSQLDatabase extends SS_Database {
 	public function tableList() {
 		$schema_SQL = pg_escape_string($this->dbConn, $this->schema);
 		$tables=array();
-		foreach($this->query("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = '{$schema_SQL}' AND tablename NOT ILIKE 'pg_%' AND tablename NOT ILIKE 'sql_%'") as $record) {
+		foreach($this->query("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = '{$schema_SQL}' AND tablename NOT ILIKE 'pg\_%' AND tablename NOT ILIKE 'sql\_%'") as $record) {
 			//$table = strtolower(reset($record));
 			$table = reset($record);
 			$tables[$table] = $table;


### PR DESCRIPTION
In the tableList() method a query is run against the pg_tables view, filtering out system tables that begin with either pg_ or sql_. However, since the underscore in each of these patterns was not being escaped properly, tables such as "SQLQueryTest_DO" were being unintentionally treated as system tables. With the ILIKE operator an underscore matches a single character.

In order to correctly match the underscore literal these characters were escaped with a backslash.

This fix is required to fix an annoying issue I had with SQLQuery tests failing in postgres. I could just rename the fixtures, but I'd rather fix the cause of the issue.
