### PR TITLE
NEW: Improve the unittest running time by not truncating tables

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -1366,6 +1366,20 @@ class PostgreSQLDatabase extends SS_Database {
 	}
 
 	/**
+	 * Delete all entries from the table instead of truncating it.
+	 *
+	 * This gives a massive speed improvement compared to using TRUNCATE, with
+	 * the caveat that primary keys are not reset etc.
+	 *
+	 * @see DatabaseAdmin::clearAllData()
+	 *
+	 * @param string $table
+	 */
+	public function clearTable($table) {
+		$this->query('DELETE FROM "'.$table.'";');
+	}
+
+	/**
 	 * Return a boolean type-formatted string
 	 *
 	 * @params array $values Contains a tokenised list of info about this data type


### PR DESCRIPTION
When clearing tables this will delete all rows instead of truncating it.

Benchmarking this change by running the full cms and framework test suit changed improved the running time from 32 minutes to 9 minutes.

If truncate functionality is needed for any special cases it should be run as

```
DB::query("TRUNCATE \"TableToTruncate\"");
```
