### PR TITLE
FIX postgres can filter on non text fields

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -2108,6 +2108,7 @@ class PostgreSQLDatabase extends SS_Database {
 		} else {
 			$comp = ($caseSensitive === true) ? 'LIKE' : 'ILIKE';
 			if($negate) $comp = 'NOT ' . $comp;
+			$field.='::text';
 		}
 		
 		return sprintf("%s %s '%s'", $field, $comp, $value);


### PR DESCRIPTION
This issue causes the comparison to fail if comparing a non text fields (for example, a date or integer). This will cause the CMS to fail in places such as Gridfield selector. 

Similar fix as this one: https://github.com/silverstripe/silverstripe-framework/pull/2242 The difference being comparisonClause(...) being more apt solution in SS 3.1
