### PR TITLE
Alias dev-master as 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## Installation
 
- 1. Extract the contents so they reside as a **postgresql** directory inside your SilverStripe project code
+ 1. Install via composer `composer require silverstripe/postgresql 1.2.*-dev` or extract the contents
+    so they reside as a `postgresql` directory inside your SilverStripe project code
  2. Open the installer by browsing to install.php, e.g. http://localhost/silverstripe/install.php
  3. Select PostgreSQL in the database list and enter your database details
 

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,17 @@
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "postgresql", "database"],
 	"authors": [
-	{
-		"name": "Sam Minnée",
-		"email": "sam@silverstripe.com"
-	}
+		{
+			"name": "Sam Minnée",
+			"email": "sam@silverstripe.com"
+		}
 	],
-
-	"require":
-	{
+	"require": {
 		"silverstripe/framework": "~3.2"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.2.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
Include composer installation instructions

This should mean users working against the dev-master branch are able to specify a version constraint, preventing future breakages during subsequent releases.
