### PR TITLE
FIX handling of fulltext indexes declared as strings

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -482,6 +482,18 @@ class PostgreSQLDatabase extends SS_Database {
 					$ts_details=$this->fulltext($this_index, $tableName, $name);
 					$fulltexts.=$ts_details['fulltexts'] . ', ';
 					$triggers.=$ts_details['triggers'];
+				} else if(is_string($this_index)) {
+					preg_match('/^fulltext\ \((.+)\)$/i', $this_index, $matches);
+					if(count($matches) == 2) {
+						$index = array(
+							'type' => 'fulltext',
+							'name' => $name,
+							'value' => $matches[1]
+						);
+						$ts_details=$this->fulltext($index, $tableName, $name);
+						$fulltexts.=$ts_details['fulltexts'] . ', ';
+						$triggers.=$ts_details['triggers'];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a bug which arose here: https://github.com/silverstripe/silverstripe-framework/pull/3179

PostgreSQL module wasn't dealing with string declarations of fulltext indexes.
