### PR TITLE
Use parseIndexSpec to cleanup fulltext specification

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -477,23 +477,12 @@ class PostgreSQLDatabase extends SS_Database {
 		$fulltexts='';
 		$triggers='';
 		if($indexes){
-			foreach($indexes as $name=>$this_index){
-				if(is_array($this_index) && $this_index['type']=='fulltext'){
-					$ts_details=$this->fulltext($this_index, $tableName, $name);
-					$fulltexts.=$ts_details['fulltexts'] . ', ';
-					$triggers.=$ts_details['triggers'];
-				} else if(is_string($this_index)) {
-					preg_match('/^fulltext\ \((.+)\)$/i', $this_index, $matches);
-					if(count($matches) == 2) {
-						$index = array(
-							'type' => 'fulltext',
-							'name' => $name,
-							'value' => $matches[1]
-						);
-						$ts_details=$this->fulltext($index, $tableName, $name);
-						$fulltexts.=$ts_details['fulltexts'] . ', ';
-						$triggers.=$ts_details['triggers'];
-					}
+			foreach($indexes as $name => $indexSpec) {
+				$indexSpec = $this->parseIndexSpec($name, $indexSpec);
+				if($indexSpec['type'] === 'fulltext') {
+					$ts_details = $this->fulltext($indexSpec, $tableName, $name);
+					$fulltexts .= $ts_details['fulltexts'] . ', ';
+					$triggers .= $ts_details['triggers'];
 				}
 			}
 		}


### PR DESCRIPTION
Some of the rewrite for index specification parsing had not been fully implemented in every place index was used. This uses the new code to solve the fulltext generation problem.

Thanks also to @micmania1 for finding the original issue and fixing it.

Also to note that the index parsing and cleanup has been implemented in core in 3.2.
