### PR TITLE
FIX allow for spaces in enum field-type default values

### DIFF
--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -721,7 +721,7 @@ class PostgreSQLDatabase extends SS_Database {
 		// TODO: this returns an empty array for the following string: int(11) not null auto_increment
 		//		 on second thoughts, why is an auto_increment field being passed through?
 
-		$pattern = '/^([\w()]+)\s?((?:not\s)?null)?\s?(default\s[\w\']+)?\s?(check\s[\w()\'",\s]+)?$/i';
+		$pattern = '/^([\w()]+)\s?((?:not\s)?null)?\s?(default\s[\w\s\']+)?\s?(check\s[\w()\'",\s]+)?$/i';
 		preg_match($pattern, $colSpec, $matches);
 
 		if(sizeof($matches)==0) return '';


### PR DESCRIPTION
A bug exist where a space in the default value for an enum field-type would result in no database update to happen for that field-type.

The bug can be replicated below.

Inside a class e.g. Page.php add the following Enum field as follows:

```php
	private static $db = array(
		'Enum' => "Enum('lorem,ip sum,dolor,sit,amet,consectetur', 'amet')"
	);
```

A dev/build would result in the following three new fields:
 * Page                                                                                                                                                                       
  + Field Page.Enum: created as varchar(255) default 'amet' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur'))                                      
  + Field Page_Live.Enum: created as varchar(255) default 'amet' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur'))                                 
  + Field Page_versions.Enum: created as varchar(255) default 'amet' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur'))

Run the dev/build again and no updates should show.


Now change the $db array as follows:

```php
	private static $db = array(
		'Enum' => "Enum('lorem,ip sum,dolor,sit,amet,consectetur', 'ip sum')"
	);
```

A dev/build results in the modified values:
 * Page                                                                                                                                                                       
  + Field Page.Enum: changed to varchar(255) default 'ip sum' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')) (from varchar(255) default 'amet' c
heck ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')))                                                                                                  
  + Field Page_Live.Enum: changed to varchar(255) default 'ip sum' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')) (from varchar(255) default 'am
et' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')))                                                                                             
  + Field Page_versions.Enum: changed to varchar(255) default 'ip sum' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')) (from varchar(255) default
 'amet' check ("Enum" in ('lorem', 'ip sum', 'dolor', 'sit', 'amet', 'consectetur')))

All subsequent dev/builds will show the same three modified fields. The database is not getting updated. The bug should be fixed in this pull-request.





