### PR TITLE
FIX: PostgreSQLQuery::seek() failed to return a row

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -36,7 +36,8 @@ class PostgreSQLQuery extends Query
 
     public function seek($row)
     {
-        return pg_result_seek($this->handle, $row);
+        pg_result_seek($this->handle, $row);
+        return pg_fetch_row($this->handle);
     }
 
     public function numRecords()


### PR DESCRIPTION
`pg_result_seek()` returns a boolean instead of the record: http://php.net/manual/en/function.pg-result-seek.php