### PR TITLE
FIX: PostgreSQLQuery::seek() returning indexed array instead of associative

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -37,7 +37,7 @@ class PostgreSQLQuery extends Query
     public function seek($row)
     {
         pg_result_seek($this->handle, $row);
-        return pg_fetch_row($this->handle);
+        return pg_fetch_assoc($this->handle);
     }
 
     public function numRecords()


### PR DESCRIPTION
derp 😅. Without the indexed array it’s useless, as we don’t know what the columns are!