### PR TITLE
Force PostgresSQLDatabaseTest

### DIFF
--- a/tests/PostgreSQLDatabaseTest.php
+++ b/tests/PostgreSQLDatabaseTest.php
@@ -11,6 +11,9 @@ use SilverStripe\PostgreSQL\PostgreSQLDatabase;
  */
 class PostgreSQLDatabaseTest extends SapphireTest
 {
+    
+    protected $usesDatabase = true;
+    
     public function testReadOnlyTransaction()
     {
         if (


### PR DESCRIPTION
From Framework 3.2 onwards, unit tests are run on the main DB unless the objects are created via fixtures or the $usesDatabase property of SapphireTest are used. This test creates two pages programatically and they appear in the main sitetree after running the test.