### PR TITLE
API Ensure table aliases longer than max characters are safely re-written

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
 
 env:

--- a/tests/PostgreSQLQueryBuilderTest.php
+++ b/tests/PostgreSQLQueryBuilderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\PostgreSQL\PostgreSQLQueryBuilder;
+
+class PostgreSQLQueryBuilderTest extends SapphireTest
+{
+    public function testLongAliases()
+    {
+        $query = new SQLSelect();
+        $longstring = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        $alias2 = $longstring . $longstring;
+        $query->selectField('*');
+        $query->addFrom('"Base"');
+        $query->addLeftJoin(
+            'Joined',
+            "\"Base\".\"ID\" = \"{$alias2}\".\"ID\"",
+            $alias2
+        );
+        $query->addWhere([
+            "\"{$alias2}\".\"Title\" = ?" => 'Value',
+        ]);
+
+        $identifier = "c4afb43_hijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        $this->assertEquals(PostgreSQLQueryBuilder::MAX_TABLE, strlen($identifier));
+
+        $expected = <<<SQL
+SELECT *
+ FROM "Base" LEFT JOIN "Joined" AS "c4afb43_hijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+ ON "Base"."ID" = "c4afb43_hijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"."ID"
+ WHERE ("c4afb43_hijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"."Title" = ?)
+SQL;
+        $builder = new PostgreSQLQueryBuilder();
+        $sql = $builder->buildSQL($query, $params);
+
+        $this->assertSQLEquals($expected, $sql);
+        $this->assertEquals(['Value'], $params);
+    }
+}


### PR DESCRIPTION
required for https://github.com/silverstripe/silverstripe-framework/pull/6939/

cc @dhensby 