### PR TITLE
Testing in PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,13 @@ language: php
 
 sudo: false
 
-php:
-  - 5.3
-
-env:
-  matrix:
-    - DB=POSTGRESQL CORE_RELEASE=3.2
-
-
 matrix:
   include:
+    - php: 5.3
+      env: DB=POSTGRESQL CORE_RELEASE=3.4
     - php: 5.6
-      env: DB=POSTGRESQL CORE_RELEASE=3.2
-    - php: 5.5
+      env: DB=POSTGRESQL CORE_RELEASE=3
+    - php: 7.0
       env: DB=POSTGRESQL CORE_RELEASE=3
 
 before_script:
@@ -25,4 +19,4 @@ before_script:
  - cd ~/builds/ss
 
 script: 
- - phpunit framework/tests 
+ - vendor/bin/phpunit framework/tests 


### PR DESCRIPTION
Now that we have support for PHP7 in SS 3.x, we should test the Postgres module against it.
I've set up the tests to run weekly on this branch (and master) via TravisCI new cron job feature.
While we have a nightly "all modules" run in silverstripe-installer, it doesn't have the same matrix coverage as this run here.

I've also removed removed tests against older (and unsupported) 3.x releases (it was testing against 3.2)