### PR TITLE
Expose as vendor module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "silverstripe/postgresql",
   "description": "SilverStripe now has tentative support for PostgreSQL ('Postgres')",
-  "type": "silverstripe-module",
+  "type": "silverstripe-vendormodule",
   "keywords": ["silverstripe", "postgresql", "database"],
   "license": "BSD-3-Clause",
   "authors": [
@@ -11,7 +11,8 @@
     }
   ],
   "require": {
-    "silverstripe/framework": "^4.0@dev"
+    "silverstripe/framework": "^4.0@dev",
+    "silverstripe/vendor-plugin": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405

```
composer config repositories.postgresql vcs https://github.com/open-sausages/silverstripe-postgresql.git
composer require "silverstripe/postgresql:dev-pulls/2/vendorise-me-baby as 2.0.x-dev"
```