### PR TITLE
getGeneratedID to use currval() which is session dependent

### DIFF
--- a/code/PostgreSQLConnector.php
+++ b/code/PostgreSQLConnector.php
@@ -116,8 +116,8 @@ class PostgreSQLConnector extends DBConnector
 
     public function getGeneratedID($table)
     {
-        $result = $this->query("SELECT last_value FROM \"{$table}_ID_seq\";")->first();
-        return $result['last_value'];
+        $result = $this->query("SELECT currval('\"{$table}_ID_seq\"')")->first();
+        return $result['currval'];
     }
 
     public function getLastError()


### PR DESCRIPTION
I've run into an issue in my load balanced environment that causes primary key duplicates. I believe this is because getGeneratedID() will return the last ID from an insert statement across all sessions, rather than just the session that did the insert. 

currval() looks to be the recommended way if you can't have "RETURNING ID" in your insert statement. As the "RETURNING ID" would be a major change, changing it to currval() would fix concurrency issues without major changes.