### PR TITLE
BUG Fix 4.0.0 compat / PDO not working

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,15 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yml,*.json}]
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,js,json,css,scss,feature}]
 indent_size = 2
+indent_style = space
+
+[composer.json]
+indent_size = 4
 
 # The indent size used in the package.json file cannot be changed:
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,69 +1,15 @@
 inherit: true
 
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
 checks:
   php:
-    verify_property_names: true
-    verify_argument_usable_as_reference: true
-    verify_access_scope_valid: true
-    useless_calls: true
-    use_statement_alias_conflict: true
-    variable_existence: true
-    unused_variables: true
-    unused_properties: true
-    unused_parameters: true
-    unused_methods: true
-    unreachable_code: true
-    too_many_arguments: true
-    sql_injection_vulnerabilities: true
-    simplify_boolean_return: true
-    side_effects_or_types: true
-    security_vulnerabilities: true
-    return_doc_comments: true
-    return_doc_comment_if_not_inferrable: true
-    require_scope_for_properties: true
-    require_scope_for_methods: true
-    require_php_tag_first: true
-    psr2_switch_declaration: true
-    psr2_class_declaration: true
-    property_assignments: true
-    prefer_while_loop_over_for_loop: true
-    precedence_mistakes: true
-    precedence_in_conditions: true
-    phpunit_assertions: true
-    php5_style_constructor: true
-    parse_doc_comments: true
-    parameter_non_unique: true
-    parameter_doc_comments: true
-    param_doc_comment_if_not_inferrable: true
-    optional_parameters_at_the_end: true
-    one_class_per_file: true
-    no_unnecessary_if: true
-    no_trailing_whitespace: true
-    no_property_on_interface: true
-    no_non_implemented_abstract_methods: true
-    no_error_suppression: true
-    no_duplicate_arguments: true
-    no_commented_out_code: true
-    newline_at_end_of_file: true
-    missing_arguments: true
-    method_calls_on_non_object: true
-    instanceof_class_exists: true
-    foreach_traversable: true
-    fix_line_ending: true
-    fix_doc_comments: true
-    duplication: true
-    deprecated_code_usage: true
-    deadlock_detection_in_loops: true
     code_rating: true
-    closure_use_not_conflicting: true
-    catch_class_exists: true
-    blank_line_after_namespace_declaration: false
-    avoid_multiple_statements_on_same_line: true
-    avoid_duplicate_types: true
-    avoid_conflicting_incrementers: true
-    avoid_closing_tag: true
-    assignment_of_null_return: true
-    argument_type_checks: true
+    duplication: true
 
 filter:
   paths: [code/*, tests/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
-dist: precise
+dist: trusty
 
-sudo: false
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - 5.6
@@ -10,23 +12,33 @@ php:
 env:
   global:
     - DB="PGSQL"
-    - CORE_RELEASE="4"
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env:
+        - PHPUNIT_TEST=framework
+    - php: 5.6
+      env:
+        - PHPUNIT_TEST=postgresql
+        - PHPCS_TEST=1
 
 before_script:
 # Init PHP
-  - printf "\n" | pecl install imagick
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - export PATH=~/.composer/vendor/bin:$PATH
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-# Temporarily update to 1.5.x-dev of composer
-  - composer self-update --snapshot
-
 # Install composer dependencies
+  - composer validate
   - composer install --prefer-dist
-  - composer require --prefer-dist --no-update symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/cms:4.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-cms:1.0.x-dev
   - composer update
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 script:
- - vendor/bin/phpunit ./tests
- - vendor/bin/phpunit ./framework/tests
+  - if [[ $PHPUNIT_TEST == postgresql ]]; then vendor/bin/phpunit ./tests; fi
+  - if [[ $PHPUNIT_TEST == framework ]]; then vendor/bin/phpunit ./vendor/silverstripe/framework/tests/php; fi
+  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi

--- a/code/PostgreSQLDatabase.php
+++ b/code/PostgreSQLDatabase.php
@@ -282,7 +282,7 @@ class PostgreSQLDatabase extends Database
 
     public function getDatabaseServer()
     {
-        return "postgresql";
+        return "pgsql";
     }
 
     /**
@@ -374,14 +374,15 @@ class PostgreSQLDatabase extends Database
 
         // Get tables
         $tablesToSearch = [];
-        foreach($classesToSearch as $class) {
+        foreach ($classesToSearch as $class) {
             $tablesToSearch[$class] = DataObject::getSchema()->baseDataTable($class);
         }
 
         //We can get a list of all the tsvector columns though this query:
         //We know what tables to search in based on the $classesToSearch variable:
         $classesPlaceholders = DB::placeholders($classesToSearch);
-        $searchableColumns = $this->preparedQuery("
+        $searchableColumns = $this->preparedQuery(
+            "
 			SELECT table_name, column_name, data_type
 			FROM information_schema.columns
 			WHERE data_type='tsvector' AND table_name in ($classesPlaceholders);",
@@ -500,7 +501,7 @@ class PostgreSQLDatabase extends Database
     /*
      * This is a quick lookup to discover if the database supports particular extensions
      */
-    public function supportsExtensions($extensions=array('partitions', 'tablespaces', 'clustering'))
+    public function supportsExtensions($extensions = array('partitions', 'tablespaces', 'clustering'))
     {
         if (isset($extensions['partitions'])) {
             return true;
@@ -683,8 +684,10 @@ class PostgreSQLDatabase extends Database
     public function schemaToDatabaseName($schema)
     {
         switch ($schema) {
-            case $this->schemaOriginal: return $this->databaseOriginal;
-            default: return $schema;
+            case $this->schemaOriginal:
+                return $this->databaseOriginal;
+            default:
+                return $schema;
         }
     }
 
@@ -698,8 +701,10 @@ class PostgreSQLDatabase extends Database
     public function databaseToSchemaName($database)
     {
         switch ($database) {
-            case $this->databaseOriginal: return $this->schemaOriginal;
-            default: return $database;
+            case $this->databaseOriginal:
+                return $this->schemaOriginal;
+            default:
+                return $database;
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,41 @@
 {
-  "name": "silverstripe/postgresql",
-  "description": "SilverStripe now has tentative support for PostgreSQL ('Postgres')",
-  "type": "silverstripe-vendormodule",
-  "keywords": ["silverstripe", "postgresql", "database"],
-  "license": "BSD-3-Clause",
-  "authors": [
-    {
-      "name": "Sam Minnée",
-      "email": "sam@silverstripe.com"
-    }
-  ],
-  "require": {
-    "silverstripe/framework": "^4.0@dev",
-    "silverstripe/vendor-plugin": "^1.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "2.0.x-dev"
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+    "name": "silverstripe/postgresql",
+    "description": "SilverStripe now has tentative support for PostgreSQL ('Postgres')",
+    "type": "silverstripe-vendormodule",
+    "keywords": [
+        "silverstripe",
+        "postgresql",
+        "database"
+    ],
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Sam Minnée",
+            "email": "sam@silverstripe.com"
+        }
+    ],
+    "require": {
+        "silverstripe/framework": "^4",
+        "silverstripe/vendor-plugin": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\PostgreSQL\\": "code/",
+            "SilverStripe\\PostgreSQL\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "lint": "phpcs code/ tests/",
+        "lint-clean": "phpcbf code/ tests/"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+	<!-- base rules are PSR-2 -->
+	<rule ref="PSR2" >
+		<!-- Current exclusions -->
+		<exclude name="PSR1.Methods.CamelCapsMethodName" />
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+		<exclude name="PSR2.Classes.PropertyDeclaration" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+		<exclude name="Squiz.Scope.MethodScope" />
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+	</rule>
+
+	<!-- include php files only -->
+    <arg name="extensions" value="php,lib,inc,php5"/>
+
+	<!-- PHP-PEG generated file not intended for human consumption -->
+	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
+    <exclude-pattern>*/_fakewebroot/*</exclude-pattern>
+    <exclude-pattern>*/fixtures/*</exclude-pattern>
+</ruleset>
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 
 	<testsuite name="Default">
 		<directory>tests</directory>

--- a/tests/PostgreSQLConnectorTest.php
+++ b/tests/PostgreSQLConnectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SilverStripe\PostgreSQL\Tests;
+
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\PostgreSQL\PostgreSQLConnector;
 
@@ -23,7 +25,7 @@ class PostgreSQLConnectorTest extends SapphireTest
 
         // Ignoring question mark placeholders within string literals
         $this->assertEquals(
-                "SELECT * FROM Table WHERE ID = $1 AND Name = $2 AND Content = '<p>What is love?</p>'",
+            "SELECT * FROM Table WHERE ID = $1 AND Name = $2 AND Content = '<p>What is love?</p>'",
             $connector->replacePlaceholders(
                 "SELECT * FROM Table WHERE ID = ? AND Name = ? AND Content = '<p>What is love?</p>'"
             )
@@ -31,7 +33,7 @@ class PostgreSQLConnectorTest extends SapphireTest
 
         // Ignoring question mark placeholders within string literals with escaped slashes
         $this->assertEquals(
-                "SELECT * FROM Table WHERE ID = $1 AND Title = '\\'' AND Content = '<p>What is love?</p>' AND Name = $2",
+            "SELECT * FROM Table WHERE ID = $1 AND Title = '\\'' AND Content = '<p>What is love?</p>' AND Name = $2",
             $connector->replacePlaceholders(
                 "SELECT * FROM Table WHERE ID = ? AND Title = '\\'' AND Content = '<p>What is love?</p>' AND Name = ?"
             )
@@ -39,7 +41,7 @@ class PostgreSQLConnectorTest extends SapphireTest
 
         // same as above, but use double single quote escape syntax
         $this->assertEquals(
-                "SELECT * FROM Table WHERE ID = $1 AND Title = '''' AND Content = '<p>What is love?</p>' AND Name = $2",
+            "SELECT * FROM Table WHERE ID = $1 AND Title = '''' AND Content = '<p>What is love?</p>' AND Name = $2",
             $connector->replacePlaceholders(
                 "SELECT * FROM Table WHERE ID = ? AND Title = '''' AND Content = '<p>What is love?</p>' AND Name = ?"
             )

--- a/tests/PostgreSQLDatabaseTest.php
+++ b/tests/PostgreSQLDatabaseTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace SilverStripe\PostgreSQL\Tests;
+
+use Exception;
+use Page;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -15,19 +19,18 @@ class PostgreSQLDatabaseTest extends SapphireTest
 
     public function testReadOnlyTransaction()
     {
-        if (
-            DB::get_conn()->supportsTransactions() == true
+        if (DB::get_conn()->supportsTransactions() == true
             && DB::get_conn() instanceof PostgreSQLDatabase
         ) {
-            $page=new Page();
-            $page->Title='Read only success';
+            $page = new Page();
+            $page->Title = 'Read only success';
             $page->write();
 
             DB::get_conn()->transactionStart('READ ONLY');
 
             try {
-                $page=new Page();
-                $page->Title='Read only page failed';
+                $page = new Page();
+                $page->Title = 'Read only page failed';
                 $page->write();
             } catch (Exception $e) {
                 //could not write this record
@@ -39,8 +42,8 @@ class PostgreSQLDatabaseTest extends SapphireTest
 
             DataObject::flush_and_destroy_cache();
 
-            $success=DataObject::get('Page', "\"Title\"='Read only success'");
-            $fail=DataObject::get('Page', "\"Title\"='Read only page failed'");
+            $success = DataObject::get('Page', "\"Title\"='Read only success'");
+            $fail = DataObject::get('Page', "\"Title\"='Read only page failed'");
 
             //This page should be in the system
             $this->assertTrue(is_object($success) && $success->exists());

--- a/tests/PostgreSQLQueryBuilderTest.php
+++ b/tests/PostgreSQLQueryBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace SilverStripe\PostgreSQL\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Queries\SQLSelect;


### PR DESCRIPTION
Includes postgres fix for https://github.com/silverstripe/silverstripe-framework/pull/7605 (non-nullable enum types)

Also adds linting to the module to match framework conventions.

PostgreSQL + PDO also wasn't working due to buggy fulltextsearch index parsing; Fixed this.

When using PDOConnector, postgres couldn't include multiple statements in a single query, so this has been split out into separate ->query() calls.

extractTriggerColumns() was not querying against the correct schema / database / table, so this has been added to the condition via a safe join.
