### PR TITLE
FIX: Boolean ’t’/‘f’ strings need to be coerced to int properly.

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -80,7 +80,11 @@ class PostgreSQLQuery extends Query
                 $record[$k] = $v;
                 $type = pg_field_type($this->handle, $i);
                 if (isset(self::$typeMapping[$type])) {
-                    settype($record[$k], self::$typeMapping[$type]);
+                    if ($type === 'bool' && $record[$k] === 't') {
+                        $record[$k] = 1;
+                    } else {
+                        settype($record[$k], self::$typeMapping[$type]);
+                    }
                 }
             }
 


### PR DESCRIPTION
Noticed this bug.

The database was returning booleans as the strings `"t"` or `"f"`. The f is being coerced to 0, but so was t. This coerces t to 1. 