### PR TITLE
Updated PDO PostgreSQL Check

### DIFF
--- a/_register_database.php
+++ b/_register_database.php
@@ -11,10 +11,10 @@ DatabaseAdapterRegistry::register(array(
     'title' => 'PostgreSQL 8.3+ (using PDO)',
     'helperPath' => __DIR__.'/code/PostgreSQLDatabaseConfigurationHelper.php',
     'helperClass' => PostgreSQLDatabaseConfigurationHelper::class,
-    'supported' => (class_exists('PDO') && in_array('postgresql', PDO::getAvailableDrivers())),
+    'supported' => (class_exists('PDO') && in_array('pgsql', PDO::getAvailableDrivers())),
     'missingExtensionText' =>
         'Either the <a href="http://www.php.net/manual/en/book.pdo.php">PDO Extension</a> or 
-		the <a href="http://www.php.net/manual/en/ref.pdo-sqlsrv.php">SQL Server PDO Driver</a> 
+		the <a href="http://www.php.net/manual/en/ref.pdo-pgsql.php">PostgreSQL PDO Driver</a> 
 		are unavailable. Please install or enable these and refresh this page.'
 ));
 


### PR DESCRIPTION
The pre-check for PostgreSQL needs to look for pgsql and changed the
error text to link to the PostgreSQL PDO documentation instead of the
Microsoft SQL Server documentation.