### PR TITLE
FIX Prevent vacuum from running multiple times during test runs

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,0 +1,8 @@
+---
+Name: postgrestest
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        disablepostgresvacuum: '%$SilverStripe\PostgreSQL\Dev\State\DisableVacuumState'

--- a/code/Dev/State/DisableVacuumState.php
+++ b/code/Dev/State/DisableVacuumState.php
@@ -5,6 +5,8 @@ namespace SilverStripe\PostgreSQL\Dev\State;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\State\TestState;
+use SilverStripe\ORM\DB;
+use SilverStripe\PostgreSQL\PostgreSQLConnector;
 use SilverStripe\PostgreSQL\PostgreSQLSchemaManager;
 
 class DisableVacuumState implements TestState
@@ -36,7 +38,9 @@ class DisableVacuumState implements TestState
      */
     public function setUpOnce($class)
     {
-        Config::modify()->set(PostgreSQLSchemaManager::class, 'check_and_repair_on_build', false);
+        if (DB::get_conn()->getConnector() instanceof PostgreSQLConnector) {
+            Config::modify()->set(PostgreSQLSchemaManager::class, 'check_and_repair_on_build', false);
+        }
     }
 
     /**

--- a/code/Dev/State/DisableVacuumState.php
+++ b/code/Dev/State/DisableVacuumState.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SilverStripe\PostgreSQL\Dev\State;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use SilverStripe\PostgreSQL\PostgreSQLSchemaManager;
+
+class DisableVacuumState implements TestState
+{
+    /**
+     * Called on setup
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+        // TODO: Implement setUp() method.
+    }
+
+    /**
+     * Called on tear down
+     *
+     * @param SapphireTest $test
+     */
+    public function tearDown(SapphireTest $test)
+    {
+        // TODO: Implement tearDown() method.
+    }
+
+    /**
+     * Called once on setup
+     *
+     * @param string $class Class being setup
+     */
+    public function setUpOnce($class)
+    {
+        Config::modify()->set(PostgreSQLSchemaManager::class, 'check_and_repair_on_build', false);
+    }
+
+    /**
+     * Called once on tear down
+     *
+     * @param string $class Class being torn down
+     */
+    public function tearDownOnce($class)
+    {
+        // TODO: Implement tearDownOnce() method.
+    }
+}


### PR DESCRIPTION
Currently the `checkAndRepairTable` implementation just re-indexes and full vacuums the table. This is run every time a table is "required" and can take a while. There's a whole debate I could have about just flat out removing this - a properly configured PostgreSQL instance should self-vacuum periodically anyway - this is more of a maintenance task rather than a "repair". Rather than getting into that though I think it at least makes sense to disable this specifically when running tests.