### PR TITLE
NEW: Drop PHP 5.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.6
+  - 7.1
 
 env:
   global:
@@ -16,10 +16,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - PHPUNIT_TEST=framework
-    - php: 5.6
+    - php: 7.1
       env:
         - PHPUNIT_TEST=postgresql
         - PHPCS_TEST=1


### PR DESCRIPTION
PostgreSQL 2.3+, like Framework 4.5+, is able to be PHP 7.1+. Updated
the test matrix to reflect this.