### PR TITLE
BUG Fix issues preventing a site from being migrated from SS3 to SS4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-dist: trusty
+dist: xenial
+
+services:
+  - postgresql
+  -
 
 cache:
   directories:
@@ -17,6 +21,12 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
+      env:
+        - PHPUNIT_TEST=framework
+    - php: 7.2
+      env:
+        - PHPUNIT_TEST=framework
+    - php: 7.3
       env:
         - PHPUNIT_TEST=framework
     - php: 7.1

--- a/code/PostgreSQLSchemaManager.php
+++ b/code/PostgreSQLSchemaManager.php
@@ -543,8 +543,8 @@ class PostgreSQLSchemaManager extends DBSchemaManager
                 if ($this->hasTable("{$tableName}_Live")) {
                     $updateConstraint .= "UPDATE \"{$tableName}_Live\" SET \"$colName\"='$default' WHERE \"$colName\" NOT IN ($constraint_values);";
                 }
-                if ($this->hasTable("{$tableName}_versions")) {
-                    $updateConstraint .= "UPDATE \"{$tableName}_versions\" SET \"$colName\"='$default' WHERE \"$colName\" NOT IN ($constraint_values);";
+                if ($this->hasTable("{$tableName}_Versions")) {
+                    $updateConstraint .= "UPDATE \"{$tableName}_Versions\" SET \"$colName\"='$default' WHERE \"$colName\" NOT IN ($constraint_values);";
                 }
 
                 $this->query($updateConstraint);

--- a/code/PostgreSQLSchemaManager.php
+++ b/code/PostgreSQLSchemaManager.php
@@ -494,9 +494,15 @@ class PostgreSQLSchemaManager extends DBSchemaManager
         // First, we split the column specifications into parts
         // TODO: this returns an empty array for the following string: int(11) not null auto_increment
         //         on second thoughts, why is an auto_increment field being passed through?
-
-        $pattern = '/^([\w(\,)]+)\s?((?:not\s)?null)?\s?(default\s[\w\.\']+)?\s?(check\s[\w()\'",\s]+)?$/i';
+        $pattern = '/^([\w(\,)]+)\s?((?:not\s)?null)?\s?(default\s[\w\.\'\\\\]+)?\s?(check\s[\w()\'",\s\\\\]+)?$/i';
         preg_match($pattern, $colSpec, $matches);
+        // example value this regex is expected to parse:
+        // varchar(255) not null default 'SS\Test\Player' check ("ClassName" in ('SS\Test\Player', 'Player', null))
+        // split into:
+        // * varchar(255)
+        // * not null
+        // * default 'SS\Test\Player'
+        // * check ("ClassName" in ('SS\Test\Player', 'Player', null))
 
         if (sizeof($matches) == 0) {
             return '';

--- a/tests/PostgreSQLSchemaManagerTest.php
+++ b/tests/PostgreSQLSchemaManagerTest.php
@@ -27,7 +27,8 @@ class PostgreSQLSchemaManagerTest extends SapphireTest
             try {
                 DB::query('INSERT INTO "ClassNamesUpgrade" ("ClassName") VALUES (\'App\MySite\FooBar\')');
                 $this->assertFalse(true, 'SS3 Constaint should have blocked the previous insert.');
-            } catch (DatabaseException $ex) { }
+            } catch (DatabaseException $ex) {
+            }
 
             $dbSchema->schemaUpdate(function () use ($dbSchema) {
                 $dbSchema->requireTable(
@@ -48,7 +49,6 @@ class PostgreSQLSchemaManagerTest extends SapphireTest
             DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade"');
             DB::query('DROP SEQUENCE IF EXISTS "ClassNamesUpgrade_ID_seq"');
         }
-
     }
 
     private function createSS3Table()
@@ -91,16 +91,15 @@ SQL
             $this->assertTableCount(1, 'ClassNamesUpgrade_Versioned');
             $this->assertConstraintCount(0, 'ClassNamesUpgrade_versioned_ClassName_check');
             $this->assertConstraintCount(1, 'ClassNamesUpgrade_Versioned_ClassName_check');
-
         } finally {
             DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade_Versioned"');
             DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade_versioned"');
             DB::query('DROP SEQUENCE IF EXISTS "ClassNamesUpgrade_versioned_ID_seq"');
         }
-
     }
 
-    private function assertConstraintCount($expected, $constraintName) {
+    private function assertConstraintCount($expected, $constraintName)
+    {
         $count = DB::prepared_query(
             'SELECT count(*) FROM pg_catalog.pg_constraint WHERE conname like ?',
             [$constraintName]
@@ -109,7 +108,8 @@ SQL
         $this->assertEquals($expected, $count);
     }
 
-    private function assertTableCount($expected, $tableName) {
+    private function assertTableCount($expected, $tableName)
+    {
         $count = DB::prepared_query(
             'SELECT count(*) FROM pg_catalog.pg_tables WHERE "tablename" like ?',
             [$tableName]

--- a/tests/PostgreSQLSchemaManagerTest.php
+++ b/tests/PostgreSQLSchemaManagerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace SilverStripe\PostgreSQL\Tests;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Connect\Database;
+use SilverStripe\ORM\Connect\DatabaseException;
+use SilverStripe\ORM\DB;
+use SilverStripe\PostgreSQL\PostgreSQLConnector;
+use SilverStripe\PostgreSQL\PostgreSQLSchemaManager;
+
+class PostgreSQLSchemaManagerTest extends SapphireTest
+{
+
+    protected $usesTransactions = false;
+
+    public function testAlterTable()
+    {
+        try {
+            /** @var PostgreSQLSchemaManager $dbSchema */
+            $dbSchema = DB::get_schema();
+            $dbSchema->quiet();
+
+            $this->createSS3Table();
+
+            try {
+                DB::query('INSERT INTO "ClassNamesUpgrade" ("ClassName") VALUES (\'App\MySite\FooBar\')');
+                $this->assertFalse(true, 'SS3 Constaint should have blocked the previous insert.');
+            } catch (DatabaseException $ex) { }
+
+            $dbSchema->schemaUpdate(function () use ($dbSchema) {
+                $dbSchema->requireTable(
+                    'ClassNamesUpgrade',
+                    [
+                        'ID' => 'PrimaryKey',
+                        'ClassName' => 'Enum(array("App\\\\MySite\\\\FooBar"))',
+                    ]
+                );
+            });
+
+            DB::query('INSERT INTO "ClassNamesUpgrade" ("ClassName") VALUES (\'App\MySite\FooBar\')');
+            $count = DB::query('SELECT count(*) FROM "ClassNamesUpgrade" WHERE "ClassName" = \'App\MySite\FooBar\'')
+                ->value();
+
+            $this->assertEquals(1, $count);
+        } finally {
+            DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade"');
+            DB::query('DROP SEQUENCE IF EXISTS "ClassNamesUpgrade_ID_seq"');
+        }
+
+    }
+
+    private function createSS3Table()
+    {
+        DB::query(<<<SQL
+CREATE SEQUENCE "ClassNamesUpgrade_ID_seq" start 1 increment 1;       
+CREATE TABLE "ClassNamesUpgrade"
+(
+  "ID" bigint NOT NULL DEFAULT nextval('"ClassNamesUpgrade_ID_seq"'::regclass),
+  "ClassName" character varying(255) DEFAULT 'ClassNamesUpgrade'::character varying,
+  CONSTRAINT "ClassNamesUpgrade_pkey" PRIMARY KEY ("ID"),
+  CONSTRAINT "ClassNamesUpgrade_ClassName_check" CHECK ("ClassName"::text = ANY (ARRAY['FooBar'::character varying::text]))
+)
+WITH (
+  OIDS=FALSE
+);
+SQL
+        );
+    }
+
+    public function testRenameTable()
+    {
+        try {
+            /** @var PostgreSQLSchemaManager $dbSchema */
+            $dbSchema = DB::get_schema();
+            $dbSchema->quiet();
+
+            $this->createSS3VersionedTable();
+
+            $this->assertConstraintCount(1, 'ClassNamesUpgrade_versioned_ClassName_check');
+
+            $dbSchema->schemaUpdate(function () use ($dbSchema) {
+                $dbSchema->renameTable(
+                    'ClassNamesUpgrade_versioned',
+                    'ClassNamesUpgrade_Versioned'
+                );
+            });
+
+            $this->assertTableCount(0, 'ClassNamesUpgrade_versioned');
+            $this->assertTableCount(1, 'ClassNamesUpgrade_Versioned');
+            $this->assertConstraintCount(0, 'ClassNamesUpgrade_versioned_ClassName_check');
+            $this->assertConstraintCount(1, 'ClassNamesUpgrade_Versioned_ClassName_check');
+
+        } finally {
+            DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade_Versioned"');
+            DB::query('DROP TABLE IF EXISTS "ClassNamesUpgrade_versioned"');
+            DB::query('DROP SEQUENCE IF EXISTS "ClassNamesUpgrade_versioned_ID_seq"');
+        }
+
+    }
+
+    private function assertConstraintCount($expected, $constraintName) {
+        $count = DB::prepared_query(
+            'SELECT count(*) FROM pg_catalog.pg_constraint WHERE conname like ?',
+            [$constraintName]
+        )->value();
+
+        $this->assertEquals($expected, $count);
+    }
+
+    private function assertTableCount($expected, $tableName) {
+        $count = DB::prepared_query(
+            'SELECT count(*) FROM pg_catalog.pg_tables WHERE "tablename" like ?',
+            [$tableName]
+        )->value();
+
+        $this->assertEquals($expected, $count);
+    }
+
+    private function createSS3VersionedTable()
+    {
+        DB::query(<<<SQL
+CREATE SEQUENCE "ClassNamesUpgrade_versioned_ID_seq" start 1 increment 1;       
+CREATE TABLE "ClassNamesUpgrade_versioned"
+(
+  "ID" bigint NOT NULL DEFAULT nextval('"ClassNamesUpgrade_versioned_ID_seq"'::regclass),
+  "ClassName" character varying(255) DEFAULT 'ClassNamesUpgrade'::character varying,
+  CONSTRAINT "ClassNamesUpgrade_pkey" PRIMARY KEY ("ID"),
+  CONSTRAINT "ClassNamesUpgrade_versioned_ClassName_check" CHECK ("ClassName"::text = ANY (ARRAY['FooBar'::character varying::text]))
+)
+WITH (
+  OIDS=FALSE
+);
+SQL
+        );
+    }
+}


### PR DESCRIPTION
This is a work in progress. I fix the initial problem that prevented ClassNames from being migrated.

But there'smore problems with Versioned tables ClassName columns ... and potentially with Polymorphic relationships.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/8344