### PR TITLE
Updated PDO PostgreSQL Connection Creation

### DIFF
--- a/code/PostgreSQLDatabaseConfigurationHelper.php
+++ b/code/PostgreSQLDatabaseConfigurationHelper.php
@@ -42,7 +42,7 @@ class PostgreSQLDatabaseConfigurationHelper implements DatabaseConfigurationHelp
                     break;
                 case 'PostgrePDODatabase':
                     // May throw a PDOException if fails
-                    $conn = @new PDO('postgresql:host='.$server.';dbname=postgres;port=5432', $username, $password);
+                    $conn = @new PDO('pgsql:host='.$server.';dbname=postgres;port=5432', $username, $password);
                     break;
                 default:
                     $error = 'Invalid connection type: ' . $databaseConfig['type'];


### PR DESCRIPTION
In addition to the pre-check for PostgreSQL needing to use pgsql
as the module name, the connection generator helper also needed
to be updated.

I missed this when submitting the last request #94 that only fixed the pre-check.