### PR TITLE
FIX Allow repeat calls to `getIterator()`

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -58,6 +58,7 @@ class PostgreSQLQuery extends Query
 
     public function getIterator()
     {
+        pg_result_seek($this->handle, 0);
         while ($data = $this->nextRecord()) {
             yield $data;
         }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "ext-pgsql": "*",
         "silverstripe/framework": "^5",
         "silverstripe/vendor-plugin": "^1.0"
     },


### PR DESCRIPTION
At the moment if you try to iterate over the result set many times all subsequent calls after the first won't return any rows.

This should fix a currently failing test in master