### PR TITLE
Enable support for jsonb field types

### DIFF
--- a/code/PostgreSQLSchemaManager.php
+++ b/code/PostgreSQLSchemaManager.php
@@ -1246,6 +1246,17 @@ class PostgreSQLSchemaManager extends DBSchemaManager
     {
         return "decimal(4,0)";
     }
+    
+     /*
+     * Return a JSON Binary field type (better for searching than a plain JSON type)
+     *
+     * @param array $values Contains a tokenised list of info about this data type
+     * @return string
+     */
+    public function json($values)
+    {
+        return "jsonb";
+    }
 
     /**
      * Create a fulltext search datatype for PostgreSQL


### PR DESCRIPTION
Adds a function to PostgreSQLSchemaManager.php to allow for FieldTypes that specify "json" as their type.  Doing so will create a jsonb column in the database, which is better for jsonpath value retrieval than it's regular json counterpart.