### PR TITLE
MNT Use PHP 8.1 for manually created CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
       # set phpunit to false to prevent automatic generation of mysql phpunit jobs
       phpunit: false
       extra_jobs: |
-        - php: 7.4
+        - php: 8.1
           db: pgsql
           phpunit: true
           composer_args: --prefer-lowest
-        - php: 8.0
+        - php: 8.1
           db: pgsql
           phpunit: true
         - php: 8.1


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/silverstripe-postgresql/runs/7757104525?check_suite_focus=true
`     - silverstripe/installer 5.x-dev requires php ^8.1 -> your php version (8.0; overridden via config.platform, actual: 8.0.21) does not satisfy that requirement.`