### PR TITLE
API Update PostgreSQLQuery to use generators

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\PostgreSQL;
 
+use Iterator;
 use SilverStripe\ORM\Connect\Query;
 
 /**
@@ -56,29 +57,16 @@ class PostgreSQLQuery extends Query
         }
     }
 
-    public function seek($row)
+    public function getIterator(): Iterator
     {
-        // Specifying the zero-th record here will reset the pointer
-        $result = pg_fetch_array($this->handle, $row, PGSQL_NUM);
-
-        return $this->parseResult($result);
+        while ($row = pg_fetch_array($this->handle, null, PGSQL_NUM)) {
+            yield $this->parseResult($row);
+        }
     }
 
     public function numRecords()
     {
         return pg_num_rows($this->handle);
-    }
-
-    public function nextRecord()
-    {
-        $row = pg_fetch_array($this->handle, null, PGSQL_NUM);
-
-        // Correct non-string types
-        if ($row) {
-            return $this->parseResult($row);
-        }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-postgresql/pull/84 from the master branch.
Requires https://github.com/silverstripe/silverstripe-framework/pull/10484 to be merged before the tests can go green.

Reinstates https://github.com/silverstripe/silverstripe-postgresql/pull/137 which was reverted in https://github.com/silverstripe/silverstripe-postgresql/pull/135 as a result of https://github.com/silverstripe/silverstripe-framework/pull/10483

## NOTE:
Do not merge UNLESS you have pulled in https://github.com/silverstripe/silverstripe-framework/pull/10484 and ran this modules tests locally and seen them go green.

## Parent Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350