### PR TITLE
FIX Reset query generator after iteration is complete

### DIFF
--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -62,6 +62,8 @@ class PostgreSQLQuery extends Query
         while ($row = pg_fetch_array($this->handle, null, PGSQL_NUM)) {
             yield $this->parseResult($row);
         }
+        // Reset so the query can be iterated over again
+        pg_result_seek($this->handle, 0);
     }
 
     public function numRecords()


### PR DESCRIPTION
The same query should be able to be executed multiple times in a row.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350