### PR TITLE
FIX Reference concrete class names for PHP 8.1

### DIFF
--- a/code/PostgreSQLConnector.php
+++ b/code/PostgreSQLConnector.php
@@ -4,6 +4,8 @@ namespace SilverStripe\PostgreSQL;
 
 use SilverStripe\ORM\Connect\DBConnector;
 use ErrorException;
+use PgSql\Connection;
+use PgSql\Result;
 
 /**
  * PostgreSQL connector class using the PostgreSQL specific api
@@ -20,7 +22,7 @@ class PostgreSQLConnector extends DBConnector
     /**
      * Connection to the PG Database database
      *
-     * @var resource
+     * @var Connection
      */
     protected $dbConn = null;
 
@@ -34,7 +36,7 @@ class PostgreSQLConnector extends DBConnector
     /**
      * Reference to the last query result (for pg_affected_rows)
      *
-     * @var resource
+     * @var Result
      */
     protected $lastQuery = null;
 

--- a/code/PostgreSQLDatabaseConfigurationHelper.php
+++ b/code/PostgreSQLDatabaseConfigurationHelper.php
@@ -6,6 +6,7 @@ use SilverStripe\Dev\Install\DatabaseAdapterRegistry;
 use SilverStripe\Dev\Install\DatabaseConfigurationHelper;
 use Exception;
 use PDO;
+use PgSql\Connection;
 
 /**
  * This is a helper class for the SS installer.
@@ -94,7 +95,7 @@ class PostgreSQLDatabaseConfigurationHelper implements DatabaseConfigurationHelp
             return false;
         } elseif ($conn instanceof PDO) {
             return $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
-        } elseif (is_resource($conn)) {
+        } elseif ($conn instanceof Connection) {
             $info = pg_version($conn);
             return $info['server'];
         } else {
@@ -132,7 +133,7 @@ class PostgreSQLDatabaseConfigurationHelper implements DatabaseConfigurationHelp
     /**
      * Helper function to execute a query
      *
-     * @param mixed $conn Connection object/resource
+     * @param mixed $conn Connection object
      * @param string $sql SQL string to execute
      * @return array List of first value from each resulting row
      */
@@ -143,7 +144,7 @@ class PostgreSQLDatabaseConfigurationHelper implements DatabaseConfigurationHelp
             foreach ($conn->query($sql) as $row) {
                 $items[] = $row[0];
             }
-        } elseif (is_resource($conn)) {
+        } elseif ($conn instanceof Connection) {
             $result =  pg_query($conn, $sql);
             while ($row = pg_fetch_row($result)) {
                 $items[] = $row[0];

--- a/code/PostgreSQLQuery.php
+++ b/code/PostgreSQLQuery.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\PostgreSQL;
 
 use Iterator;
+use PgSql\Result;
 use SilverStripe\ORM\Connect\Query;
 
 /**
@@ -15,7 +16,7 @@ class PostgreSQLQuery extends Query
 {
     /**
      * The internal Postgres handle that points to the result set.
-     * @var resource
+     * @var Result
      */
     private $handle;
 
@@ -38,7 +39,7 @@ class PostgreSQLQuery extends Query
 
     /**
      * Hook the result-set given into a Query class, suitable for use by sapphire.
-     * @param resource $handle the internal Postgres handle that is points to the resultset.
+     * @param Result $handle the internal Postgres handle that is points to the resultset.
      */
     public function __construct($handle)
     {
@@ -52,9 +53,7 @@ class PostgreSQLQuery extends Query
 
     public function __destruct()
     {
-        if (is_resource($this->handle)) {
-            pg_free_result($this->handle);
-        }
+        pg_free_result($this->handle);
     }
 
     public function getIterator(): Iterator


### PR DESCRIPTION
The result and connection are not resources in PHP 8.1

## Parent issue
-  https://github.com/silverstripe/silverstripe-postgresql/issues/141