### PR TITLE
BUG Use more robust logic to retrieve generated ID

### DIFF
--- a/code/PostgreSQLConnector.php
+++ b/code/PostgreSQLConnector.php
@@ -113,7 +113,7 @@ class PostgreSQLConnector extends DBConnector
 
     public function getGeneratedID($table)
     {
-        return $this->query("SELECT currval('\"{$table}_ID_seq\"')")->value();
+        return $this->query("SELECT currval(pg_get_serial_sequence('\"{$table}\"','ID'))")->value();
     }
 
     public function getLastError()


### PR DESCRIPTION
I not sure why, but occasionally the sequence column for an ID column won't match it's expected name. That came through when scaffolding a many_many_through relation for an eager loading test.

Following the recommendation from this [Stack overflow answer](https://stackoverflow.com/a/2944481/1427439), I've updated the logic to use a more robust approach.

## Parent issue
- https://github.com/silverstripe/silverstripe-postgresql/issues/149
 